### PR TITLE
Improve student activity registration system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn
 httpx
 watchfiles
+pytest
+pytest-asyncio

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,60 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    "Basketball Team": {
+        "description": "Join the school basketball team for training and games",
+        "schedule": "Mondays and Thursdays, 5:00 PM - 7:00 PM",
+        "max_participants": 15,
+        "participants": []
+    },
+    "Swim Club": {
+        "description": "Team swimming, lap practice, and stroke improvement",
+        "schedule": "Tuesdays and Fridays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": []
+    },
+    "Track and Field": {
+        "description": "Sprint drills, distance training, and athletic conditioning",
+        "schedule": "Wednesdays and Saturdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
+    },
+    "Art Club": {
+        "description": "Drawing, painting, and creative design projects",
+        "schedule": "Tuesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 20,
+        "participants": []
+    },
+    "Drama & Theater": {
+        "description": "Acting, stagecraft, and school performances",
+        "schedule": "Thursdays, 4:00 PM - 6:00 PM",
+        "max_participants": 25,
+        "participants": []
+    },
+    "Music Ensemble": {
+        "description": "Band and choir rehearsals for concerts",
+        "schedule": "Mondays and Wednesdays, 4:30 PM - 6:00 PM",
+        "max_participants": 30,
+        "participants": []
+    },
+    "Robotics Club": {
+        "description": "Build and program robots for competitions",
+        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:30 PM",
+        "max_participants": 18,
+        "participants": []
+    },
+    "Science Olympiad": {
+        "description": "Prepare for science and engineering tournaments",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 20,
+        "participants": []
+    },
+    "Chess Team": {
+        "description": "Advanced strategy sessions and club competitions",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 16,
+        "participants": []
     }
 }
 
@@ -61,6 +115,11 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Get the specific activity
     activity = activities[activity_name]
+# Validate student is not already signed up
+    if email in activity["participants"]:
+        raise HTTPException(
+            status_code=400, detail="Student already signed up for this activity")  
+    
 
     # Add student
     activity["participants"].append(email)

--- a/src/app.py
+++ b/src/app.py
@@ -124,3 +124,21 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+@app.delete("/activities/{activity_name}/participants/{email}")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+
+    # Get the specific activity
+    activity = activities[activity_name]
+
+    # Check if student is signed up
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student is not signed up for this activity")
+
+    # Remove student
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -10,6 +10,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+import copy
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -20,7 +21,7 @@ app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
 # In-memory activity database
-activities = {
+initial_activities = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
@@ -94,6 +95,14 @@ activities = {
         "participants": []
     }
 }
+
+activities = copy.deepcopy(initial_activities)
+
+
+def reset_activities():
+    """Reset activities to initial state. Used for testing."""
+    global activities
+    activities = copy.deepcopy(initial_activities)
 
 
 @app.get("/")

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -19,12 +19,21 @@ document.addEventListener("DOMContentLoaded", () => {
         activityCard.className = "activity-card";
 
         const spotsLeft = details.max_participants - details.participants.length;
+        const participantsHtml = details.participants.length > 0
+          ? details.participants.map(p => `<div class="participant-item"><span>${p}</span><button class="delete-btn" data-activity="${name}" data-email="${p}">×</button></div>`).join("")
+          : "<p class=\"no-participants\">No participants signed up yet.</p>";
 
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <strong>Participants:</strong>
+            <div class="participants-list">
+              ${participantsHtml}
+            </div>
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);
@@ -34,6 +43,29 @@ document.addEventListener("DOMContentLoaded", () => {
         option.value = name;
         option.textContent = name;
         activitySelect.appendChild(option);
+      });
+
+      // Add event listeners for delete buttons
+      document.querySelectorAll('.delete-btn').forEach(btn => {
+        btn.addEventListener('click', async (e) => {
+          const activity = e.target.dataset.activity;
+          const email = e.target.dataset.email;
+          try {
+            const response = await fetch(`/activities/${encodeURIComponent(activity)}/participants/${encodeURIComponent(email)}`, {
+              method: 'DELETE'
+            });
+            if (response.ok) {
+              // Refresh activities
+              fetchActivities();
+            } else {
+              const result = await response.json();
+              alert(result.detail || 'Failed to unregister');
+            }
+          } catch (error) {
+            alert('Failed to unregister. Please try again.');
+            console.error(error);
+          }
+        });
       });
     } catch (error) {
       activitiesList.innerHTML = "<p>Failed to load activities. Please try again later.</p>";
@@ -62,6 +94,8 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        // Refresh activities to show the new participant
+        fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,61 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 10px;
+  padding: 10px;
+  border-radius: 5px;
+  background-color: #f0f4ff;
+  border: 1px solid #cbd6ee;
+}
+
+.participants-section strong {
+  display: block;
+  margin-bottom: 6px;
+  color: #1a237e;
+}
+
+.participants-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.participant-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 8px;
+  background-color: #fff;
+  border-radius: 3px;
+  border: 1px solid #e0e0e0;
+}
+
+.delete-btn {
+  background: none;
+  border: none;
+  color: #c62828;
+  font-size: 18px;
+  cursor: pointer;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  transition: background-color 0.2s;
+}
+
+.delete-btn:hover {
+  background-color: #ffebee;
+}
+
+.no-participants {
+  font-style: italic;
+  color: #666;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests package

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+from fastapi.testclient import TestClient
+from src.app import app, reset_activities
+
+
+@pytest.fixture
+def client():
+    """Test client fixture for FastAPI app."""
+    reset_activities()  # Reset to initial state before each test
+    return TestClient(app)

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -1,0 +1,114 @@
+"""Tests for activities endpoints."""
+import pytest
+
+
+def test_get_activities(client):
+    """Test getting all activities."""
+    response = client.get("/activities")
+    assert response.status_code == 200
+    data = response.json()
+
+    # Should return a dictionary with activity names as keys
+    assert isinstance(data, dict)
+    assert len(data) > 0  # Should have activities
+
+    # Check structure of first activity
+    first_activity = next(iter(data.values()))
+    assert "description" in first_activity
+    assert "schedule" in first_activity
+    assert "max_participants" in first_activity
+    assert "participants" in first_activity
+    assert isinstance(first_activity["participants"], list)
+
+
+def test_signup_success(client):
+    """Test successful student signup."""
+    activity_name = "Chess Club"
+    email = "student@test.edu"
+
+    response = client.post(f"/activities/{activity_name}/signup?email={email}")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "message" in data
+    assert email in data["message"]
+
+    # Verify the email was added to participants
+    response = client.get("/activities")
+    activities = response.json()
+    assert email in activities[activity_name]["participants"]
+
+
+def test_signup_duplicate(client):
+    """Test duplicate signup prevention."""
+    activity_name = "Chess Club"
+    email = "duplicate@test.edu"
+
+    # First signup should succeed
+    response = client.post(f"/activities/{activity_name}/signup?email={email}")
+    assert response.status_code == 200
+
+    # Second signup should fail
+    response = client.post(f"/activities/{activity_name}/signup?email={email}")
+    assert response.status_code == 400
+    data = response.json()
+    assert "detail" in data
+    assert "already signed up" in data["detail"].lower()
+
+
+def test_signup_invalid_activity(client):
+    """Test signup to non-existent activity."""
+    activity_name = "NonExistent Activity"
+    email = "student@test.edu"
+
+    response = client.post(f"/activities/{activity_name}/signup?email={email}")
+    assert response.status_code == 404
+    data = response.json()
+    assert "detail" in data
+    assert "not found" in data["detail"].lower()
+
+
+def test_unregister_success(client):
+    """Test successful unregistration."""
+    activity_name = "Chess Club"
+    email = "unregister@test.edu"
+
+    # First signup
+    client.post(f"/activities/{activity_name}/signup?email={email}")
+
+    # Then unregister
+    response = client.delete(f"/activities/{activity_name}/participants/{email}")
+    assert response.status_code == 200
+
+    data = response.json()
+    assert "message" in data
+    assert email in data["message"]
+
+    # Verify the email was removed from participants
+    response = client.get("/activities")
+    activities = response.json()
+    assert email not in activities[activity_name]["participants"]
+
+
+def test_unregister_not_registered(client):
+    """Test unregistering non-participant."""
+    activity_name = "Chess Club"
+    email = "notregistered@test.edu"
+
+    response = client.delete(f"/activities/{activity_name}/participants/{email}")
+    assert response.status_code == 400
+    data = response.json()
+    assert "detail" in data
+    assert "not signed up" in data["detail"].lower()
+
+
+def test_unregister_invalid_activity(client):
+    """Test unregistering from non-existent activity."""
+    activity_name = "NonExistent Activity"
+    email = "student@test.edu"
+
+    response = client.delete(f"/activities/{activity_name}/participants/{email}")
+    assert response.status_code == 404
+    data = response.json()
+    assert "detail" in data
+    assert "not found" in data["detail"].lower()

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,0 +1,81 @@
+"""Tests for edge cases and additional validation."""
+import pytest
+
+
+def test_email_case_sensitivity(client):
+    """Test if emails are case-sensitive."""
+    activity_name = "Chess Club"
+    email_lower = "student@test.edu"
+    email_upper = "STUDENT@TEST.EDU"
+
+    # Signup with lowercase
+    response = client.post(f"/activities/{activity_name}/signup?email={email_lower}")
+    assert response.status_code == 200
+
+    # Try to signup with uppercase - should be treated as different email
+    response = client.post(f"/activities/{activity_name}/signup?email={email_upper}")
+    # Based on current implementation, emails are case-sensitive
+    # If this succeeds, emails are case-sensitive
+    # If it fails with 400, they are case-insensitive
+    # From app.py, it uses list membership which is case-sensitive in Python
+    assert response.status_code == 200  # Should succeed as different email
+
+
+def test_activity_name_with_spaces(client):
+    """Test activity names with spaces."""
+    activity_name = "Chess Club"  # Has space
+    email = "student@test.edu"
+
+    response = client.post(f"/activities/{activity_name}/signup?email={email}")
+    assert response.status_code == 200
+
+    # Verify in activities list
+    response = client.get("/activities")
+    activities = response.json()
+    assert activity_name in activities
+    assert email in activities[activity_name]["participants"]
+
+
+def test_empty_email_signup(client):
+    """Test signup with empty email."""
+    activity_name = "Chess Club"
+    email = ""
+
+    response = client.post(f"/activities/{activity_name}/signup?email={email}")
+    # Current implementation doesn't validate email format
+    # It will accept empty string
+    assert response.status_code == 200
+
+    # Verify empty email was added
+    response = client.get("/activities")
+    activities = response.json()
+    assert "" in activities[activity_name]["participants"]
+
+
+def test_special_characters_in_activity_name(client):
+    """Test activity names with special characters."""
+    # Use an activity with special characters
+    activity_name = "Drama & Theater"  # Has space and &
+    email = "student@test.edu"
+
+    response = client.post(f"/activities/{activity_name}/signup?email={email}")
+    assert response.status_code == 200
+
+
+def test_max_participants_not_enforced(client):
+    """Test that max_participants is not currently enforced."""
+    activity_name = "Chess Club"
+    email1 = "student1@test.edu"
+    email2 = "student2@test.edu"
+
+    # Get max participants for Chess Club
+    response = client.get("/activities")
+    activities = response.json()
+    max_participants = activities[activity_name]["max_participants"]
+
+    # Signup more than max_participants
+    for i in range(max_participants + 1):
+        email = f"student{i}@test.edu"
+        response = client.post(f"/activities/{activity_name}/signup?email={email}")
+        # Current implementation doesn't check max_participants
+        assert response.status_code == 200


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes core signup behavior (now rejects duplicates) and introduces a new delete endpoint/UI flow that could affect activity rosters if misused or incorrectly encoded.
> 
> **Overview**
> **Improves activity roster management and test coverage.** The API now prevents duplicate signups and adds `DELETE /activities/{activity_name}/participants/{email}` to unregister a student.
> 
> The in-memory dataset is expanded with additional activities and refactored into `initial_activities` plus a `reset_activities()` helper for tests. The UI now displays participant lists per activity with per-participant remove buttons and refreshes the activity list after signup/unregister, with new CSS for the participants section.
> 
> Adds `pytest`/`pytest-asyncio` dependencies and a new `tests/` suite covering listing activities, signup success/duplicate/invalid activity, unregister scenarios, and a few edge-case behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37ab46bb1dd1896e88c6ce87dad06c788d21f151. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->